### PR TITLE
Fixed addFile bug -- method is 'POST' and needs the user's token to be passed.

### DIFF
--- a/assets/scripts/file/api.js
+++ b/assets/scripts/file/api.js
@@ -21,7 +21,10 @@ const addFile = function (data) {
   console.log('data is ', data)
   return $.ajax({
     url: 'http://localhost:4741/files',
-    method: 'GET',
+    method: 'POST',
+    headers: {
+      Authorization: 'Token token=' + store.token
+    },
     data,
     contentType: false,
     processData: false
@@ -34,7 +37,7 @@ const updateFile = function (data) {
     url: config.apiOrigin + '/files/' + store.fileId,
     method: 'PATCH',
     headers: {
-      Authorization: 'Token token=' + store.userToken
+      Authorization: 'Token token=' + store.token
     },
     data
   })


### PR DESCRIPTION
With these fixes, the backend gets to 'create' in the files
controller. The backend returns a 500 to the frontend. A console.log
in 'create' shows that 'req.body.file' is undefined.