### PR TITLE
The Tag in the Update File modal is now correctly initialized

### DIFF
--- a/assets/scripts/file/ui.js
+++ b/assets/scripts/file/ui.js
@@ -73,8 +73,12 @@ const openAddModal = function (event) {
 const openEditModal = function (event) {
   store.fileName = $(event.target).parent().data('type')
   store.fileId = $(event.target).parent().data('id')
+  store.fileTag = $(event.target).parent().data('tag')
   $('.modal-folder-name').text(`Folder: ${store.folder}`)
   $('.modal-file-name').text(`File: ${store.fileName}`)
+
+  // To select a value in the dropdown, it the html element must be prepended the id.  $('select#addTagNew') works; $('#addTagNew') does not
+  $('select#addTagNew').val(store.fileTag)
 }
 
 const highlightRows = function () {

--- a/assets/scripts/templates/file-listing.handlebars
+++ b/assets/scripts/templates/file-listing.handlebars
@@ -1,14 +1,14 @@
 {{#each files as |file|}}
 <tr>
 
-  <td class="col-xs-2" align="center" data-id="{{file.id}}" data-type="{{file.name}}">
+  <td class="col-xs-2" align="center" data-id="{{file.id}}" data-type="{{file.name}}" data-tag="{{file.tag}}">
 
 
     <a href="{{file.url}}" class="btn btn-default open-file-download" data-id="{{file.id}}">
       <em class="fa fa-download"></em>
     </a>
 
-    <a class="btn btn-default open-file-edit" data-id="{{file.id}}" data-toggle="modal" data-target=".file-update-modal" data-type="{{file.name}}">
+    <a class="btn btn-default open-file-edit" data-id="{{file.id}}" data-toggle="modal" data-target=".file-update-modal" data-type="{{file.name}}" data-tag="{{file.tag}}">
       <em class="fa fa-pencil"></em>
     </a>
 

--- a/index.html
+++ b/index.html
@@ -271,9 +271,9 @@
                   <div class="form-group">
                     <label for="addTagNew">Add a Tag:</label>
                     <select name="file[tag]" class="form-control" id="addTagNew">
-                      <option>New</option>
-                      <option>Pending</option>
-                      <option>Complete</option>
+                      <option value="New">New</option>
+                      <option value="Pending">Pending</option>
+                      <option value="Complete">Complete</option>
                     </select>
                   </div>
 


### PR DESCRIPTION
to the file's Tag as seen in the file list.

Pair programmed with @artpylon

A value attribute was added to the option tag in index.html. This value
will be set to the file's Tag to initial the dropdown correctly.

Note: In jQuery, it the html element must be prepended to the id --
$('select#addTagNew') works; $('#addTagNew') does not.